### PR TITLE
map headers as arrays of objects with key and value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@
 
 var crypto = require('crypto');
 var integration = require('segmentio-integration');
+var isPlainObject = require('is-plain-object');
 var url = require('url');
 var Batch = require('batch');
 var LRU = require('lru-cache');
@@ -105,7 +106,7 @@ function request(message, done){
         key: hook,
         value: {
           hook: hook,
-          headers: {}
+          headers: []
         }
       }
     };
@@ -132,10 +133,18 @@ function request(message, done){
     batch.push(function(done){
       var req = self
         .post(url)
-        .set(headers)
         .type('json')
         .send(body)
         .parse(ignore);
+
+      // check if headers is plain object (default) and set to array if so
+      if (isPlainObject(headers)) headers = [];
+
+      headers.forEach(function(header) {
+        if (header.key && header.value) {
+          req.set(header.key, header.value)
+        }
+      });
 
       if (digest) req.set('X-Signature', digest);
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "batch": "^0.5.2",
+    "is-plain-object": "^2.0.1",
     "lru-cache": "^4.0.0",
     "ms": "^0.7.1",
     "segmentio-integration": "^3.0.5"

--- a/test/index.js
+++ b/test/index.js
@@ -31,9 +31,10 @@ describe('Webhooks', function(){
         key: 'http://localhost:4000',
         value: {
           hook: 'http://localhost:4000',
-          headers: {
-            'X-wheels': 'value'
-          }
+          headers: [{
+            key: 'X-wheels',
+            value: 'value'
+          }]
         }
       }]
     };
@@ -116,6 +117,28 @@ describe('Webhooks', function(){
           .end(done);
       });
 
+      it('should not throw when `.hooks$value.headers` is an object', function(done){
+        var route = '/' + type + '/success';
+        settings.hooks = [{
+          key: route,
+          value: {
+            hook: route,
+            headers: {}
+          }
+        }];
+
+        app.post(route, function(req, res){
+          assert.deepEqual(req.body, json.output);
+          res.send(200);
+        });
+
+        test
+          .set(settings)
+          [type](json.input)
+          .expects(200)
+          .end(done);
+      });
+
       it('should not throw when `.hooks` is an array of strings', function(done){
         var route = '/' + type + '/success';
         settings.hooks[0] = 'http://localhost:4000' + route;
@@ -144,19 +167,19 @@ describe('Webhooks', function(){
           key: route1,
           value: {
             hook: route1,
-            headers: {}
+            headers: []
           }
         }, {
           key: route2,
           value: {
             hook: route2,
-            headers: {}
+            headers: []
           }
         }, {
           key: route1,
           value: {
             hook: route1,
-            headers: {}
+            headers: []
           }
         }];
 
@@ -197,37 +220,37 @@ describe('Webhooks', function(){
           key: route,
           value: {
             hook: route,
-            headers: {}
+            headers: []
           }
         }, {
           key: route,
           value: {
             hook: route,
-            headers: {}
+            headers: []
           }
         }, {
           key: route,
           value: {
             hook: route,
-            headers: {}
+            headers: []
           }
         },{
           key: route,
           value: {
             hook: route,
-            headers: {}
+            headers: []
           }
         }, {
           key: route,
           value: {
             hook: route,
-            headers: {}
+            headers: []
           }
         }, {
           key: route,
           value: {
             hook: route,
-            headers: {}
+            headers: []
           }
         }];
 
@@ -255,13 +278,13 @@ describe('Webhooks', function(){
           key: route1,
           value: {
             hook: route1,
-            headers: {}
+            headers: []
           }
         }, {
           key: route2,
           value: {
             hook: route2,
-            headers: {}
+            headers: []
           }
         }];
 
@@ -358,7 +381,7 @@ describe('Webhooks', function(){
           key: 'http://localhost:4000/no',
           value: {
             hook: 'http://localhost:4000/no',
-            headers: {}
+            headers: []
           }
         }
         settings.hooks.push(failed);


### PR DESCRIPTION
@hankim813 made the same mistake here as with nanigans: nested settings maps from fields within type mixed are saved as arrays of objects like `[{ key: '', value: '' } //,...]`